### PR TITLE
Add board UI with DnD

### DIFF
--- a/client/src/components/Board/Board.tsx
+++ b/client/src/components/Board/Board.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { Grid } from '@material-ui/core';
+import useStyles from './useStyles';
+import { Droppable, DragDropContext, DropResult } from 'react-beautiful-dnd';
+import Column from './Column';
+import mockData from './mockData';
+
+export default function Board(): JSX.Element {
+  const classes = useStyles();
+  const [boardState, setBoardState] = useState(mockData);
+
+  const onDragEnd = (result: DropResult) => {
+    const { destination, source, draggableId, type } = result;
+
+    if (!destination || (destination.droppableId === source.droppableId && destination.index === source.index)) {
+      return;
+    }
+
+    if (type === 'COLUMN') {
+      const newColumnOrder = [...boardState.columnOrder];
+      newColumnOrder.splice(source.index, 1);
+      newColumnOrder.splice(destination.index, 0, draggableId);
+      setBoardState({
+        ...boardState,
+        columnOrder: newColumnOrder,
+      });
+      return;
+    }
+
+    const sourceColumn = boardState.columns[source.droppableId];
+    const sourceTaskIds = [...sourceColumn.taskIds];
+
+    sourceTaskIds.splice(source.index, 1);
+
+    // if moving task to a different column, both destination and source columns must be updated
+    if (destination.droppableId !== source.droppableId) {
+      const destColumn = boardState.columns[destination.droppableId];
+      const destTaskIds = [...destColumn.taskIds];
+
+      destTaskIds.splice(destination.index, 0, draggableId);
+
+      const oldColumn = {
+        ...sourceColumn,
+        taskIds: sourceTaskIds,
+      };
+
+      const newColumn = {
+        ...destColumn,
+        taskIds: destTaskIds,
+      };
+
+      const newState = {
+        ...boardState,
+        columns: {
+          ...boardState.columns,
+          [oldColumn.id]: oldColumn,
+          [newColumn.id]: newColumn,
+        },
+      };
+
+      setBoardState(newState);
+      return;
+    }
+
+    sourceTaskIds.splice(destination.index, 0, draggableId);
+
+    const newColumn = {
+      ...sourceColumn,
+      taskIds: sourceTaskIds,
+    };
+
+    const newState = {
+      ...boardState,
+      columns: {
+        ...boardState.columns,
+        [newColumn.id]: newColumn,
+      },
+    };
+
+    setBoardState(newState);
+  };
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Droppable droppableId="board" direction="horizontal" type="COLUMN">
+        {(provided) => (
+          <Grid
+            container
+            direction="row"
+            className={classes.boardContainer}
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+          >
+            {boardState &&
+              boardState.columnOrder.map((columnId, index) => {
+                const column = boardState.columns[columnId];
+                const tasks = column.taskIds.map((taskId: string) => boardState.tasks[taskId]);
+                return <Column key={column.id} column={column} tasks={tasks} index={index} />;
+              })}
+            {provided.placeholder}
+          </Grid>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}

--- a/client/src/components/Board/Column.tsx
+++ b/client/src/components/Board/Column.tsx
@@ -1,0 +1,48 @@
+import { Grid, Typography } from '@material-ui/core';
+import useStyles from './useStyles';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import { Draggable, Droppable } from 'react-beautiful-dnd';
+import { IPropColumn, IPropTask } from '../../interface/Board';
+import Task from './Task';
+import { theme } from '../../themes/theme';
+
+interface Props {
+  column: IPropColumn;
+  tasks: IPropTask[];
+  index: number;
+}
+
+export default function Column({ column, tasks, index }: Props): JSX.Element {
+  const classes = useStyles(theme);
+  return (
+    <Draggable draggableId={column.id} index={index}>
+      {(provided) => (
+        <Grid container item className={classes.columnContainer} ref={provided.innerRef} {...provided.draggableProps}>
+          <Grid
+            container
+            direction="row"
+            alignItems="center"
+            className={classes.columnHeader}
+            {...provided.dragHandleProps}
+          >
+            <h2>{column.title}</h2>
+            <MoreHorizIcon color="disabled" />
+          </Grid>
+          <Droppable droppableId={column.id} type="TASK">
+            {(provided) => (
+              <Grid className={classes.taskList} ref={provided.innerRef} {...provided.droppableProps}>
+                {tasks.map((task, idx) => (
+                  <Task key={task.id} task={task} index={idx} />
+                ))}
+                {provided.placeholder}
+              </Grid>
+            )}
+          </Droppable>
+          <Grid item className={classes.columnFooter}>
+            <Typography variant="subtitle1">Add a card...</Typography>
+          </Grid>
+        </Grid>
+      )}
+    </Draggable>
+  );
+}

--- a/client/src/components/Board/Task.tsx
+++ b/client/src/components/Board/Task.tsx
@@ -1,0 +1,33 @@
+import { Typography, CardContent, Card, Box } from '@material-ui/core';
+import useStyles from './useStyles';
+import { Draggable } from 'react-beautiful-dnd';
+import { IPropTask } from '../../interface/Board';
+
+interface Props {
+  task: IPropTask;
+  index: number;
+}
+
+export default function Task({ task, index }: Props): JSX.Element {
+  const classes = useStyles();
+  return (
+    <Draggable draggableId={task.id} index={index}>
+      {(provided, snapshot) => (
+        <Card
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          className={snapshot.isDragging ? classes.draggingTask : classes.taskContainer}
+        >
+          <CardContent>
+            <Box className={classes.tag} style={{ backgroundColor: task.tag ?? 'white' }}></Box>
+            <Typography variant="h6" className={classes.taskContent}>
+              <strong>{task.content}</strong>
+            </Typography>
+            <Typography variant="subtitle2">{task.date ?? ''}</Typography>
+          </CardContent>
+        </Card>
+      )}
+    </Draggable>
+  );
+}

--- a/client/src/components/Board/Task.tsx
+++ b/client/src/components/Board/Task.tsx
@@ -13,20 +13,24 @@ export default function Task({ task, index }: Props): JSX.Element {
   return (
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
-        <Card
+        <div
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          className={snapshot.isDragging ? classes.draggingTask : classes.taskContainer}
+          className={classes.taskContainer}
         >
-          <CardContent>
-            <Box className={classes.tag} style={{ backgroundColor: task.tag ?? 'white' }}></Box>
-            <Typography variant="h6" className={classes.taskContent}>
-              <strong>{task.content}</strong>
-            </Typography>
-            <Typography variant="subtitle2">{task.date ?? ''}</Typography>
-          </CardContent>
-        </Card>
+          <Card className={snapshot.isDragging ? classes.draggingTask : undefined}>
+            <CardContent>
+              <Box className={classes.tag} style={{ backgroundColor: task.tag ?? 'white' }}></Box>
+              <Typography variant="h6" className={classes.taskContent}>
+                <strong>{task.content}</strong>
+              </Typography>
+              <Typography variant="subtitle2">
+                {task.date?.toLocaleDateString('en-us', { month: 'long', day: '2-digit' }) ?? ''}
+              </Typography>
+            </CardContent>
+          </Card>
+        </div>
       )}
     </Draggable>
   );

--- a/client/src/components/Board/mockData.tsx
+++ b/client/src/components/Board/mockData.tsx
@@ -1,0 +1,38 @@
+import { IBoardData } from '../../interface/Board';
+
+const mockData: IBoardData = {
+  tasks: {
+    'task-1': { id: 'task-1', content: 'Essay on the environment', tag: 'green' },
+    'task-2': { id: 'task-2', content: 'Midterm exam', date: 'March 10', tag: 'red' },
+    'task-3': { id: 'task-3', content: 'Practice exam', tag: 'red' },
+    'task-4': { id: 'task-4', content: 'Homework', tag: 'red' },
+    'task-5': { id: 'task-5', content: 'Workshop', tag: 'orange' },
+    'task-6': { id: 'task-6', content: 'Practice exam', tag: 'red' },
+    'task-7': { id: 'task-7', content: 'Research', tag: 'green' },
+  },
+  columns: {
+    'column-1': {
+      id: 'column-1',
+      title: 'Philosophy',
+      taskIds: ['task-1'],
+    },
+    'column-2': {
+      id: 'column-2',
+      title: 'Math',
+      taskIds: ['task-2'],
+    },
+    'column-3': {
+      id: 'column-3',
+      title: 'In progress',
+      taskIds: ['task-3', 'task-4'],
+    },
+    'column-4': {
+      id: 'column-4',
+      title: 'Completed',
+      taskIds: ['task-5', 'task-6', 'task-7'],
+    },
+  },
+  columnOrder: ['column-1', 'column-2', 'column-3', 'column-4'],
+};
+
+export default mockData;

--- a/client/src/components/Board/mockData.tsx
+++ b/client/src/components/Board/mockData.tsx
@@ -3,7 +3,7 @@ import { IBoardData } from '../../interface/Board';
 const mockData: IBoardData = {
   tasks: {
     'task-1': { id: 'task-1', content: 'Essay on the environment', tag: 'green' },
-    'task-2': { id: 'task-2', content: 'Midterm exam', date: 'March 10', tag: 'red' },
+    'task-2': { id: 'task-2', content: 'Midterm exam', date: new Date(2021, 3, 10), tag: 'red' },
     'task-3': { id: 'task-3', content: 'Practice exam', tag: 'red' },
     'task-4': { id: 'task-4', content: 'Homework', tag: 'red' },
     'task-5': { id: 'task-5', content: 'Workshop', tag: 'orange' },

--- a/client/src/components/Board/useStyles.ts
+++ b/client/src/components/Board/useStyles.ts
@@ -1,0 +1,47 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  boardContainer: {
+    maxWidth: '90%',
+    flexWrap: 'nowrap',
+    margin: '20px auto',
+    justifyContent: 'space-evenly',
+  },
+  columnHeader: {
+    justifyContent: 'space-between',
+    padding: '5px 20px',
+  },
+  columnContainer: {
+    margin: '8px',
+    backgroundColor: theme.palette.info.main,
+    borderRadius: '10px',
+    flexDirection: 'column',
+    blockSize: 'fit-content',
+  },
+  taskList: {
+    blockSize: 'fit-content',
+  },
+  columnFooter: {
+    padding: '10px 20px',
+  },
+  taskContainer: {
+    width: '93%',
+    margin: '10px auto',
+    minHeight: '85px',
+    maxHeight: '100px',
+  },
+  taskContent: {
+    marginTop: '8px',
+  },
+  draggingTask: {
+    transform: 'rotate(-5deg)', // gets overridden by dnd properties
+  },
+  tag: {
+    backgroundColor: 'green',
+    height: '8px',
+    width: '60px',
+    borderRadius: '5px',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/Board/useStyles.ts
+++ b/client/src/components/Board/useStyles.ts
@@ -34,7 +34,8 @@ const useStyles = makeStyles((theme) => ({
     marginTop: '8px',
   },
   draggingTask: {
-    transform: 'rotate(-5deg)', // gets overridden by dnd properties
+    transform: 'rotate(-5deg)',
+    transition: 'transform 300ms ease',
   },
   tag: {
     backgroundColor: 'green',

--- a/client/src/interface/Board.ts
+++ b/client/src/interface/Board.ts
@@ -1,0 +1,35 @@
+export interface IBoardData {
+  tasks: ITask;
+  columns: IColumn;
+  columnOrder: string[];
+}
+
+export interface ITask {
+  [name: string]: {
+    id: string;
+    content: string;
+    tag?: string;
+    date?: string;
+  };
+}
+
+export interface IColumn {
+  [name: string]: {
+    id: string;
+    title: string;
+    taskIds: string[];
+  };
+}
+
+export interface IPropColumn {
+  id: string;
+  title: string;
+  taskIds: string[];
+}
+
+export interface IPropTask {
+  id: string;
+  content: string;
+  tag?: string;
+  date?: string;
+}

--- a/client/src/interface/Board.ts
+++ b/client/src/interface/Board.ts
@@ -9,7 +9,7 @@ export interface ITask {
     id: string;
     content: string;
     tag?: string;
-    date?: string;
+    date?: Date;
   };
 }
 
@@ -31,5 +31,5 @@ export interface IPropTask {
   id: string;
   content: string;
   tag?: string;
-  date?: string;
+  date?: Date;
 }

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -8,9 +8,26 @@ export const theme = createMuiTheme({
       textTransform: 'none',
       fontWeight: 700,
     },
+    h6: {
+      fontSize: '1rem',
+    },
+    subtitle1: {
+      color: '#acb9db',
+      fontWeight: 'bolder',
+      fontSize: '.8rem',
+    },
+    subtitle2: {
+      color: '#b2b2b2',
+      fontSize: '.8rem',
+    },
   },
   palette: {
     primary: { main: '#3A8DFF' },
+    info: {
+      main: '#F4F6FF',
+      light: '#B5B6BD',
+      dark: '#E5ECFC',
+    },
   },
   shape: {
     borderRadius: 5,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "devDependencies": {
+    "@types/react-beautiful-dnd": "^13.1.1",
     "husky": "^6.0.0",
     "prettier": "^2.3.1",
     "pretty-quick": "^3.1.1"
   },
   "scripts": {
     "prepare": "husky install"
+  },
+  "dependencies": {
+    "react-beautiful-dnd": "^13.1.0"
   }
 }


### PR DESCRIPTION
### What this PR does (required):
- Adds board UI with drag n drop functionality.

### Screenshots / Videos (required):
![boardui](https://user-images.githubusercontent.com/67487694/128057621-81191a5c-8fc2-4ff8-a01a-56bd5493fb38.PNG)

### Any information needed to test this feature (required):
- Import the Board component from `src/components/Board.tsx`. Currently it is set up to use mock data from the `mockData.tsx` file in the same folder.

### Any issues with the current functionality (optional):
- When dragging, the task cards don't tilt as shown in the screenshot examples. I think this is because Beautiful DnD overwrites the `transform` property when moving the cards, which is what I was using to apply the tilt.