### PR TITLE
Add new column/task dialog & useImmer

### DIFF
--- a/client/src/components/Board/Board.tsx
+++ b/client/src/components/Board/Board.tsx
@@ -3,11 +3,23 @@ import { Grid } from '@material-ui/core';
 import useStyles from './useStyles';
 import { Droppable, DragDropContext, DropResult } from 'react-beautiful-dnd';
 import Column from './Column';
+import NewColumnButton from './NewColumnButton';
 import mockData from './mockData';
+import MainModal from './Modals/MainModal';
+import { INewTask } from '../../interface/Board';
+import { useImmerReducer } from 'use-immer';
+import reducer, { setDraggedColumn, setDraggedTask, setNewColumn, setNewTask } from '../../utils/reducer';
 
 export default function Board(): JSX.Element {
   const classes = useStyles();
-  const [boardState, setBoardState] = useState(mockData);
+  const [isOpen, setIsOpen] = useState(false);
+  const [columnSide, setColumnSide] = useState('');
+
+  const [state, dispatch] = useImmerReducer(reducer, mockData);
+
+  const toggleModal = () => {
+    setIsOpen(!isOpen);
+  };
 
   const onDragEnd = (result: DropResult) => {
     const { destination, source, draggableId, type } = result;
@@ -16,91 +28,60 @@ export default function Board(): JSX.Element {
       return;
     }
 
+    const columnData = {
+      sourceIndex: source.index,
+      destinationIndex: destination.index,
+      draggableId: draggableId,
+    };
+
     if (type === 'COLUMN') {
-      const newColumnOrder = [...boardState.columnOrder];
-      newColumnOrder.splice(source.index, 1);
-      newColumnOrder.splice(destination.index, 0, draggableId);
-      setBoardState({
-        ...boardState,
-        columnOrder: newColumnOrder,
-      });
+      dispatch(setDraggedColumn(columnData));
       return;
     }
 
-    const sourceColumn = boardState.columns[source.droppableId];
-    const sourceTaskIds = [...sourceColumn.taskIds];
-
-    sourceTaskIds.splice(source.index, 1);
-
-    // if moving task to a different column, both destination and source columns must be updated
-    if (destination.droppableId !== source.droppableId) {
-      const destColumn = boardState.columns[destination.droppableId];
-      const destTaskIds = [...destColumn.taskIds];
-
-      destTaskIds.splice(destination.index, 0, draggableId);
-
-      const oldColumn = {
-        ...sourceColumn,
-        taskIds: sourceTaskIds,
-      };
-
-      const newColumn = {
-        ...destColumn,
-        taskIds: destTaskIds,
-      };
-
-      const newState = {
-        ...boardState,
-        columns: {
-          ...boardState.columns,
-          [oldColumn.id]: oldColumn,
-          [newColumn.id]: newColumn,
-        },
-      };
-
-      setBoardState(newState);
-      return;
-    }
-
-    sourceTaskIds.splice(destination.index, 0, draggableId);
-
-    const newColumn = {
-      ...sourceColumn,
-      taskIds: sourceTaskIds,
+    const taskData = {
+      ...columnData,
+      sourceId: source.droppableId,
+      destinationId: destination.droppableId,
     };
 
-    const newState = {
-      ...boardState,
-      columns: {
-        ...boardState.columns,
-        [newColumn.id]: newColumn,
-      },
-    };
+    dispatch(setDraggedTask(taskData));
+  };
 
-    setBoardState(newState);
+  const addTask = (newTask: INewTask) => {
+    dispatch(setNewTask(newTask));
+  };
+
+  const addColumn = (title: string) => {
+    dispatch(setNewColumn(title, columnSide));
   };
 
   return (
-    <DragDropContext onDragEnd={onDragEnd}>
-      <Droppable droppableId="board" direction="horizontal" type="COLUMN">
-        {(provided) => (
-          <Grid
-            container
-            direction="row"
-            className={classes.boardContainer}
-            ref={provided.innerRef}
-            {...provided.droppableProps}
-          >
-            {boardState &&
-              boardState.columnOrder.map((columnId, index) => {
-                const column = boardState.columns[columnId];
-                const tasks = column.taskIds.map((taskId: string) => boardState.tasks[taskId]);
-                return <Column key={column.id} column={column} tasks={tasks} index={index} />;
-              })}
-            {provided.placeholder}
-          </Grid>
-        )}
-      </Droppable>
-    </DragDropContext>
+    <Grid container direction="row" className={classes.boardContainer}>
+      <NewColumnButton toggleModal={toggleModal} setColumnSide={setColumnSide} side={'left'} />
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="board" direction="horizontal" type="COLUMN">
+          {(provided) => (
+            <Grid
+              container
+              direction="row"
+              className={classes.board}
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+            >
+              {state &&
+                state.columnOrder.map((columnId, index) => {
+                  const column = state.columns[columnId];
+                  const tasks = column.taskIds.map((taskId: string) => state.tasks[taskId]);
+                  return <Column key={column.id} column={column} tasks={tasks} index={index} addTask={addTask} />;
+                })}
+              {provided.placeholder}
+            </Grid>
+          )}
+        </Droppable>
+      </DragDropContext>
+      <NewColumnButton toggleModal={toggleModal} setColumnSide={setColumnSide} side={'right'} />
+      <MainModal isOpen={isOpen} isColumn={true} closeModal={toggleModal} addColumn={addColumn} />
+    </Grid>
   );
 }

--- a/client/src/components/Board/Column.tsx
+++ b/client/src/components/Board/Column.tsx
@@ -17,10 +17,10 @@ interface Props {
 
 export default function Column({ column, tasks, index, addTask }: Props): JSX.Element {
   const classes = useStyles(theme);
-  const [showNewTask, setShowNewTask] = useState(false);
+  const [showForm, setShowForm] = useState(false);
 
   const handleClick = () => {
-    setShowNewTask(!showNewTask);
+    setShowForm((showForm) => !showForm);
   };
 
   return (
@@ -44,7 +44,7 @@ export default function Column({ column, tasks, index, addTask }: Props): JSX.El
                   <Task key={task.id} task={task} index={idx} />
                 ))}
                 {provided.placeholder}
-                {showNewTask ? (
+                {showForm ? (
                   <NewTaskForm addTask={addTask} closeForm={handleClick} columnId={column.id} />
                 ) : (
                   <Button className={classes.newTaskBtn} onClick={handleClick}>

--- a/client/src/components/Board/Column.tsx
+++ b/client/src/components/Board/Column.tsx
@@ -1,19 +1,28 @@
-import { Grid, Typography } from '@material-ui/core';
+import { useState } from 'react';
+import { Grid, Button } from '@material-ui/core';
 import useStyles from './useStyles';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
-import { IPropColumn, IPropTask } from '../../interface/Board';
+import { IPropColumn, IPropTask, INewTask } from '../../interface/Board';
 import Task from './Task';
+import NewTaskForm from './Forms/NewTaskForm';
 import { theme } from '../../themes/theme';
 
 interface Props {
   column: IPropColumn;
   tasks: IPropTask[];
   index: number;
+  addTask: (newTask: INewTask) => void;
 }
 
-export default function Column({ column, tasks, index }: Props): JSX.Element {
+export default function Column({ column, tasks, index, addTask }: Props): JSX.Element {
   const classes = useStyles(theme);
+  const [showNewTask, setShowNewTask] = useState(false);
+
+  const handleClick = () => {
+    setShowNewTask(!showNewTask);
+  };
+
   return (
     <Draggable draggableId={column.id} index={index}>
       {(provided) => (
@@ -35,12 +44,16 @@ export default function Column({ column, tasks, index }: Props): JSX.Element {
                   <Task key={task.id} task={task} index={idx} />
                 ))}
                 {provided.placeholder}
+                {showNewTask ? (
+                  <NewTaskForm addTask={addTask} closeForm={handleClick} columnId={column.id} />
+                ) : (
+                  <Button className={classes.newTaskBtn} onClick={handleClick}>
+                    Add a card...
+                  </Button>
+                )}
               </Grid>
             )}
           </Droppable>
-          <Grid item className={classes.columnFooter}>
-            <Typography variant="subtitle1">Add a card...</Typography>
-          </Grid>
         </Grid>
       )}
     </Draggable>

--- a/client/src/components/Board/Forms/NewTaskForm.tsx
+++ b/client/src/components/Board/Forms/NewTaskForm.tsx
@@ -1,0 +1,93 @@
+import { Card, CardContent, Typography, Grid, Button, IconButton, InputBase } from '@material-ui/core';
+import { INewTask } from '../../../interface/Board';
+import useStyles from '../useStyles';
+import { useImmer } from 'use-immer';
+
+// white, green, red, orange, blue, purple
+const tagColors = ['#fff', '#5acd76', '#ff5d48', '#edab1d', '#59b0ff', '#d460f7'];
+const initialState = { content: '', tag: '', error: false };
+
+interface Props {
+  addTask: (newTask: INewTask) => void;
+  closeForm: () => void;
+  columnId: string;
+}
+
+export default function NewTaskForm({ addTask, closeForm, columnId }: Props): JSX.Element {
+  const classes = useStyles();
+
+  const [form, updateForm] = useImmer(initialState);
+
+  const updateContent = (content: string) => {
+    updateForm((draft) => {
+      draft.content = content;
+    });
+  };
+
+  const updateTag = (tag: string) => {
+    updateForm((draft) => {
+      draft.tag = tag;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (form.content) {
+      addTask({
+        content: form.content,
+        tag: form.tag,
+        columnId: columnId,
+      });
+      updateForm(initialState);
+      closeForm();
+    } else {
+      updateForm((draft) => {
+        draft.error = true;
+      });
+    }
+  };
+
+  return (
+    <Grid>
+      <Card className={classes.newTaskContainer}>
+        <CardContent className={classes.inputContainer}>
+          <InputBase
+            required
+            name="content"
+            defaultValue="Add title..."
+            onChange={(e) => updateContent(e.target.value)}
+            className={classes.contentInput}
+            error={form.error}
+            fullWidth
+            autoComplete="off"
+          />
+        </CardContent>
+        <CardContent>
+          <Grid container direction="row" justifyContent="space-between">
+            <Typography variant="subtitle2">Select Tag:</Typography>
+            <Grid item>
+              {tagColors.map((color, index) => {
+                const border = color === form.tag ? '2px solid #759CFC' : '2px solid #F4F6FF';
+                return (
+                  <IconButton
+                    key={index}
+                    onClick={() => updateTag(color)}
+                    style={{
+                      border: border,
+                      backgroundColor: color,
+                    }}
+                    className={classes.tagButton}
+                  ></IconButton>
+                );
+              })}
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+      <Grid item className={classes.columnFooter}>
+        <Button variant="contained" color="primary" onClick={handleSubmit}>
+          Add a card
+        </Button>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/components/Board/Modals/MainModal.tsx
+++ b/client/src/components/Board/Modals/MainModal.tsx
@@ -1,0 +1,73 @@
+import {
+  Button,
+  TextField,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  Typography,
+  IconButton,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import { useState } from 'react';
+import useStyles from './useStyles';
+
+interface Props {
+  isOpen: boolean;
+  isColumn: boolean;
+  closeModal: () => void;
+  addColumn: (newTask: string) => void;
+}
+
+// this is set up to work with both the new column and 'create board' buttons
+export default function MainModal({ isOpen, isColumn, closeModal, addColumn }: Props): JSX.Element {
+  const classes = useStyles();
+  const [title, setTitle] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = () => {
+    if (title.trim()) {
+      setError('');
+      addColumn(title);
+      closeModal();
+    } else {
+      setError('Please enter a valid title');
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} aria-labelledby="form-dialog-title" maxWidth="xs" fullWidth>
+      <Grid container justifyContent="flex-end">
+        <IconButton onClick={closeModal} className={classes.closeBtn}>
+          <CloseIcon className={classes.icon} />
+        </IconButton>
+      </Grid>
+      <Grid container direction="column" alignItems="center">
+        <DialogTitle id="form-dialog-title" disableTypography={true}>
+          <Typography variant="h4">
+            <strong>Create a new {isColumn ? 'column' : 'board'}</strong>
+          </Typography>
+        </DialogTitle>
+        <DialogContent className={classes.input}>
+          <TextField
+            autoFocus
+            id="title"
+            type="text"
+            defaultValue="Add Title"
+            variant="outlined"
+            error={error !== ''}
+            helperText={error}
+            fullWidth
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions className={classes.createBtn}>
+          <Button color="primary" variant="contained" size="large" onClick={handleSubmit} fullWidth>
+            Create
+          </Button>
+        </DialogActions>
+      </Grid>
+    </Dialog>
+  );
+}

--- a/client/src/components/Board/Modals/useStyles.ts
+++ b/client/src/components/Board/Modals/useStyles.ts
@@ -1,0 +1,23 @@
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  closeBtn: {
+    top: 10,
+    right: 10,
+    position: 'relative',
+  },
+  icon: {
+    height: 25,
+    width: 25,
+  },
+  input: {
+    margin: '30px 0',
+    width: '80%',
+  },
+  createBtn: {
+    margin: '30px 0',
+    width: '25%',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/Board/NewColumnButton.tsx
+++ b/client/src/components/Board/NewColumnButton.tsx
@@ -1,0 +1,58 @@
+import useStyles from './useStyles';
+import { Grid, IconButton } from '@material-ui/core';
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
+import { ReactNode } from 'react';
+import { useState } from 'react';
+
+interface ComponentProps {
+  children: ReactNode;
+  setHover: (arg: boolean) => void;
+}
+
+const HoverableZone = function ({ children, setHover }: ComponentProps) {
+  const classes = useStyles();
+  const handleMouseEnter = () => {
+    setHover(true);
+  };
+
+  const handleMouseLeave = () => {
+    setHover(false);
+  };
+
+  return (
+    <Grid
+      container
+      alignItems="center"
+      justifyContent="center"
+      className={classes.hoverableZone}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </Grid>
+  );
+};
+
+interface Props {
+  toggleModal: () => void;
+  setColumnSide: (side: string) => void;
+  side: string;
+}
+
+export default function NewColumnButton({ toggleModal, setColumnSide, side }: Props): JSX.Element {
+  const classes = useStyles();
+  const [hover, setHover] = useState(false);
+  const handleClick = () => {
+    setColumnSide(side);
+    toggleModal();
+  };
+  return (
+    <HoverableZone setHover={setHover}>
+      {hover && (
+        <IconButton onClick={handleClick} className={classes.addColumnBtn}>
+          <AddCircleOutlineIcon className={classes.icon} />
+        </IconButton>
+      )}
+    </HoverableZone>
+  );
+}

--- a/client/src/components/Board/NewColumnButton.tsx
+++ b/client/src/components/Board/NewColumnButton.tsx
@@ -1,8 +1,7 @@
 import useStyles from './useStyles';
 import { Grid, IconButton } from '@material-ui/core';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
-import { ReactNode } from 'react';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 interface ComponentProps {
   children: ReactNode;

--- a/client/src/components/Board/mockData.tsx
+++ b/client/src/components/Board/mockData.tsx
@@ -2,13 +2,13 @@ import { IBoardData } from '../../interface/Board';
 
 const mockData: IBoardData = {
   tasks: {
-    'task-1': { id: 'task-1', content: 'Essay on the environment', tag: 'green' },
-    'task-2': { id: 'task-2', content: 'Midterm exam', date: new Date(2021, 3, 10), tag: 'red' },
-    'task-3': { id: 'task-3', content: 'Practice exam', tag: 'red' },
-    'task-4': { id: 'task-4', content: 'Homework', tag: 'red' },
-    'task-5': { id: 'task-5', content: 'Workshop', tag: 'orange' },
-    'task-6': { id: 'task-6', content: 'Practice exam', tag: 'red' },
-    'task-7': { id: 'task-7', content: 'Research', tag: 'green' },
+    'task-1': { id: 'task-1', content: 'Essay on the environment', tag: '#5acd76' },
+    'task-2': { id: 'task-2', content: 'Midterm exam', date: new Date(2021, 3, 10), tag: '#ff5d48' },
+    'task-3': { id: 'task-3', content: 'Practice exam', tag: '#ff5d48' },
+    'task-4': { id: 'task-4', content: 'Homework', tag: '#ff5d48' },
+    'task-5': { id: 'task-5', content: 'Workshop', tag: '#edab1d' },
+    'task-6': { id: 'task-6', content: 'Practice exam', tag: '#ff5d48' },
+    'task-7': { id: 'task-7', content: 'Research', tag: '#5acd76' },
   },
   columns: {
     'column-1': {

--- a/client/src/components/Board/useStyles.ts
+++ b/client/src/components/Board/useStyles.ts
@@ -2,10 +2,16 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   boardContainer: {
-    maxWidth: '90%',
+    height: '70vh',
+    margin: '5vh 0',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  board: {
+    flex: 1,
     flexWrap: 'nowrap',
-    margin: '20px auto',
     justifyContent: 'space-evenly',
+    maxWidth: '80%',
   },
   columnHeader: {
     justifyContent: 'space-between',
@@ -22,13 +28,40 @@ const useStyles = makeStyles((theme) => ({
     blockSize: 'fit-content',
   },
   columnFooter: {
-    padding: '10px 20px',
+    padding: '3%',
+    marginBottom: '5%',
+  },
+  newTaskBtn: {
+    color: '#b2b2b2',
+    marginLeft: '3%',
+  },
+  inputContainer: {
+    borderBottom: '1px solid #b2b2b2',
+    padding: '12px 15px',
+  },
+  contentInput: {
+    fontWeight: 'bolder',
+  },
+  tagButton: {
+    height: 20,
+    width: 20,
+    borderRadius: 20,
+    margin: '0 2px',
+    padding: 0,
   },
   taskContainer: {
-    width: '93%',
-    margin: '10px auto',
+    width: '94%',
+    margin: '5px auto',
     minHeight: '85px',
     maxHeight: '100px',
+    borderRadius: 10,
+  },
+  newTaskContainer: {
+    width: '94%',
+    margin: '5px auto',
+    height: '110px',
+    border: `2px solid ${theme.palette.primary.main}`,
+    borderRadius: 10,
   },
   taskContent: {
     marginTop: '8px',
@@ -42,6 +75,20 @@ const useStyles = makeStyles((theme) => ({
     height: '8px',
     width: '60px',
     borderRadius: '5px',
+  },
+  hoverableZone: {
+    height: '100%',
+    width: '5%',
+  },
+  addColumnBtn: {
+    height: '100%',
+    width: '100%',
+    borderRadius: '0',
+  },
+  icon: {
+    height: 45,
+    width: 45,
+    color: '#FFF',
   },
 }));
 

--- a/client/src/interface/Board.ts
+++ b/client/src/interface/Board.ts
@@ -8,7 +8,7 @@ export interface ITask {
   [name: string]: {
     id: string;
     content: string;
-    tag?: string;
+    tag: string;
     date?: Date;
   };
 }
@@ -30,6 +30,12 @@ export interface IPropColumn {
 export interface IPropTask {
   id: string;
   content: string;
-  tag?: string;
+  tag: string;
   date?: Date;
+}
+
+export interface INewTask {
+  content: string;
+  tag: string;
+  columnId: string;
 }

--- a/client/src/interface/BoardActions.ts
+++ b/client/src/interface/BoardActions.ts
@@ -1,0 +1,21 @@
+export interface IColumnAction {
+  type: 'ADD_COLUMN';
+  title: string;
+  side: string;
+}
+
+export interface ITaskAction {
+  type: 'ADD_TASK';
+  content: string;
+  tag: string;
+  columnId: string;
+}
+
+export interface IMoveAction {
+  type?: 'MOVE_COLUMN' | 'MOVE_TASK';
+  sourceIndex: number;
+  destinationIndex: number;
+  sourceId?: string;
+  destinationId?: string;
+  draggableId: string;
+}

--- a/client/src/utils/reducer.ts
+++ b/client/src/utils/reducer.ts
@@ -1,0 +1,58 @@
+import { addTaskToColumn, addColumnToBoard, moveColumn, moveTask } from './reducerFunctions';
+import { IColumnAction, ITaskAction, IMoveAction } from '../interface/BoardActions';
+import { IBoardData, INewTask } from '../interface/Board';
+
+// Actions
+
+const ADD_TASK = 'ADD_TASK';
+const ADD_COLUMN = 'ADD_COLUMN';
+const MOVE_TASK = 'MOVE_TASK';
+const MOVE_COLUMN = 'MOVE_COLUMN';
+
+// Action creators
+
+export const setNewTask = (task: INewTask): ITaskAction => {
+  return {
+    type: ADD_TASK,
+    ...task,
+  };
+};
+
+export const setNewColumn = (title: string, side: string): IColumnAction => {
+  return {
+    type: ADD_COLUMN,
+    title: title,
+    side: side,
+  };
+};
+
+export const setDraggedTask = (data: IMoveAction): IMoveAction => {
+  return {
+    type: MOVE_TASK,
+    ...data,
+  };
+};
+
+export const setDraggedColumn = (data: IMoveAction): IMoveAction => {
+  return {
+    type: MOVE_COLUMN,
+    ...data,
+  };
+};
+
+// Reducer
+
+type IActions = IColumnAction | ITaskAction | IMoveAction;
+
+export default function reducer(draft: IBoardData, action: IActions): void {
+  switch (action.type) {
+    case ADD_TASK:
+      return addTaskToColumn(draft, action);
+    case ADD_COLUMN:
+      return addColumnToBoard(draft, action);
+    case MOVE_TASK:
+      return moveTask(draft, action);
+    case MOVE_COLUMN:
+      return moveColumn(draft, action);
+  }
+}

--- a/client/src/utils/reducerFunctions.ts
+++ b/client/src/utils/reducerFunctions.ts
@@ -1,0 +1,56 @@
+import { IBoardData } from '../interface/Board';
+import { IColumnAction, ITaskAction, IMoveAction } from '../interface/BoardActions';
+
+export function addTaskToColumn(state: IBoardData, data: ITaskAction): void {
+  const { content, tag, columnId } = data;
+  const taskId = content; // for now use content as ID, later integrate back-end to return newly created contentID
+
+  state.tasks[taskId] = {
+    id: taskId,
+    content: content,
+    tag: tag,
+  };
+  state.columns[columnId].taskIds.push(taskId);
+}
+
+const getNewColumnOrder = (state: IBoardData, side: string, columnId: string) => {
+  if (side === 'right') {
+    return [...state.columnOrder, columnId];
+  } else {
+    return [columnId, ...state.columnOrder];
+  }
+};
+
+export function addColumnToBoard(state: IBoardData, data: IColumnAction): void {
+  const { title, side } = data;
+  const columnId = title; // for now use title as ID, later integrate back-end
+
+  state.columnOrder = getNewColumnOrder(state, side, columnId);
+  state.columns[columnId] = {
+    id: columnId,
+    title: title,
+    taskIds: [],
+  };
+}
+
+export function moveTask(state: IBoardData, data: IMoveAction): void {
+  const { sourceIndex, destinationIndex, sourceId, destinationId, draggableId } = data;
+
+  if (!sourceId || !destinationId) return;
+
+  state.columns[sourceId].taskIds.splice(sourceIndex, 1);
+
+  // if moving task to a different column, both destination and source columns must be updated
+  if (destinationId !== sourceId) {
+    state.columns[destinationId].taskIds.splice(destinationIndex, 0, draggableId);
+    return;
+  }
+
+  state.columns[sourceId].taskIds.splice(destinationIndex, 0, draggableId);
+}
+
+export function moveColumn(state: IBoardData, data: IMoveAction): void {
+  const { sourceIndex, destinationIndex, draggableId } = data;
+  state.columnOrder.splice(sourceIndex, 1);
+  state.columnOrder.splice(destinationIndex, 0, draggableId);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,11 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
+    "immer": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.5.tgz",
+      "integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ=="
+    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -345,6 +350,11 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "use-immer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.6.0.tgz",
+      "integrity": "sha512-dFGRfvWCqPDTOt/S431ETYTg6+uxbpb7A1pptufwXVzGJY3RlXr38+3wyLNpc6SbbmAKjWl6+EP6uW74fkEsXQ=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "react-beautiful-dnd": "^13.1.0"
+    "immer": "^9.0.5",
+    "react-beautiful-dnd": "^13.1.0",
+    "use-immer": "^0.6.0"
   }
 }


### PR DESCRIPTION
### What this PR does (required):
- Adds dialogs for creating new tasks and columns to the board, along with refactoring board logic to use `useImmerReducer`.

### Screenshots / Videos (required):
![columns-tasks-dialog-pr](https://user-images.githubusercontent.com/67487694/128826713-d976f329-9e30-4941-9939-6a0c4dbd8b40.PNG)

### Any information needed to test this feature (required):
- Install `use-immer` dependancy.

### Any issues with the current functionality (optional):
- Currently there is no way to close the new task dialog once opened except by creating a new task.
- The new task form does not display form errors.
- Board state eventually needs to be moved to use Context.
